### PR TITLE
fix json parsing error

### DIFF
--- a/create-an-erc20-compatible-token.md
+++ b/create-an-erc20-compatible-token.md
@@ -33,7 +33,7 @@ ganache-cli --seed apple banana cherry
 {
   "name": "hellotoken",
   "version": "1.0.0",
-  "description": "hello token example",
+  "description": "hello token example"
 }
 ```
 


### PR DESCRIPTION
fix json format error
```
$ sudo npm install zeppelin-solidity
npm ERR! file /home/owenwen/package.json
npm ERR! code EJSONPARSE
npm ERR! Failed to parse json
npm ERR! Unexpected token } in JSON at position 88 while parsing near '...llo token example",
npm ERR! }
npm ERR! '
npm ERR! File: /home/owenwen/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/owenwen/.npm/_logs/2018-08-27T06_19_59_823Z-debug.log
```